### PR TITLE
Fix update of $calc field when having multiple fields with same name

### DIFF
--- a/integrationm/scripts/_calc.groovy
+++ b/integrationm/scripts/_calc.groovy
@@ -65,8 +65,6 @@ def evaluateExpression(calculation,instanceFields,temporaryResults) {
     def resultado = new BigDecimal(0)
     def args = getCalculationArguments(calculation,instanceFields,temporaryResults)
 
-    log.info("### HM: user=${msg.user} id=${msg.instance.id} fields=${instanceFields.collect {f -> f.fieldDefinition.name}} args=${args} calculation=${calculation}")
-
     if(calculation.op == "multiply" && args.size() > 0) {
         resultado = 1
         args.each { arg -> resultado = resultado.multiply(new BigDecimal(arg?.trim() ?: 0)) }


### PR DESCRIPTION
The $calc doesn't take in consideration the visibility of fields and in a situation where multiple fields had the same name, the update message to RM would send the last calc value and RM would only update the visible field causing it to have the wrong value.